### PR TITLE
Multiple keys

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     "periodicnoise" : "https://github.com/Jimdo/puppet-periodicnoise.git"
+    "puppetlabs-stdlib" : "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "duplicity": "#{source_dir}"

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -115,7 +115,7 @@ define duplicity::job(
     } else {
       $_pubkeys = [$_pubkey_id]
     }
-    $_encryption = inline_template('<% _pubkeys.each do |key| %>--encrypt-key \'<%= key %>\' <% end %>')
+    $_encryption = inline_template('--gpg-options \'--trust-model=always\' <% _pubkeys.each do |key| %>--encrypt-key \'<%= key %>\' <% end %>')
     $_keystr = join([ "'", join($_pubkeys, "' '"), "'" ], '')
     $_numkeys = size($_pubkeys)
     exec { "duplicity-pgp-$title":

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -132,7 +132,7 @@ describe 'duplicity::job' do
 
     it "should use pubkey encryption if keyid is provided" do
       should contain_file(spoolfile) \
-        .with_content(/--encrypt-key '#{some_pubkey_id}'/)
+        .with_content(/--gpg-options '--trust-model=always' --encrypt-key '#{some_pubkey_id}'/)
     end
 
     it "should download and import the specified pubkey" do
@@ -160,7 +160,7 @@ describe 'duplicity::job' do
 
     it "should use pubkey encryption for both keys" do
       should contain_file(spoolfile) \
-        .with_content(/--encrypt-key '#{first_key}' --encrypt-key '#{second_key}'/)
+        .with_content(/--gpg-options '--trust-model=always' --encrypt-key '#{first_key}' --encrypt-key '#{second_key}'/)
     end
 
     it "should download and import the specified pubkey" do

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -139,7 +139,7 @@ describe 'duplicity::job' do
       should contain_exec("duplicity-pgp-#{title}") \
         .with_command("gpg --keyserver subkeys.pgp.net --recv-keys '#{some_pubkey_id}'") \
         .with_path("/usr/bin:/usr/sbin:/bin") \
-        .with_unless(/gpg --list-keys '#{some_pubkey_id}'/)
+        .with_unless(/gpg .* --list-keys '#{some_pubkey_id}'/)
     end
   end
 
@@ -167,7 +167,7 @@ describe 'duplicity::job' do
       should contain_exec("duplicity-pgp-#{title}") \
         .with_command("gpg --keyserver subkeys.pgp.net --recv-keys '#{first_key}' '#{second_key}'") \
         .with_path("/usr/bin:/usr/sbin:/bin") \
-        .with_unless(/gpg --list-keys '#{first_key}' '#{second_key}'/)
+        .with_unless(/gpg .* --list-keys '#{first_key}' '#{second_key}'/)
     end
   end
 


### PR DESCRIPTION
This allows you to specify multiple encryption keys. This is usefull is you want to encrypt your backups to the keys of several admins so that in case of a key loss you still have access to your backups.

ed5530c adds GPG parameters to always trust the keys specified on the duplicity command line. Otherwise you have to tell GPG that your keys have ultimate trust or sign the keys with a key that is trusted in GPG. Having this on a server is not really a good idea in all circumstances. As the keys are given by keyid you can also just trust them. If you are worried about keyid collisions, just specify the full fingerprint.

This adds a dependency on puppetlabs-stdlib. I don't think this should be a problem, but if you disagree, I can look into ways to reimplemented the needed functions inside the module.

If you want to merge all my pull request I also have them all merged into one branch on https://github.com/cirrax/puppet-duplicity/tree/cirrax