### PR TITLE
Silence backup jobs

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -114,7 +114,7 @@ define duplicity::job(
 
   $_remove_older_than_command = $_remove_older_than ? {
     undef => '',
-    default => " && duplicity remove-older-than $_remove_older_than --s3-use-new-style $_encryption --force $_target_url"
+    default => " && duplicity remove-older-than $_remove_older_than --verbosity warning --s3-use-new-style $_encryption --force $_target_url"
   }
 
   file { $spoolfile:

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -47,7 +47,7 @@ describe 'duplicity::job' do
       should contain_file(spoolfile) \
         .with_content(/^CLOUDFILES_USERNAME='some_id'$/)\
         .with_content(/^CLOUDFILES_APIKEY='some_key'$/)\
-        .with_content(/^duplicity --full-if-older-than 30D --s3-use-new-style --no-encryption --include '\/etc\/' --exclude '\*\*' \/ 'cf\+http:\/\/somebucket'$/)
+        .with_content(/^duplicity --verbosity warning --no-print-statistics --full-if-older-than 30D --s3-use-new-style --no-encryption --include '\/etc\/' --exclude '\*\*' \/ 'cf\+http:\/\/somebucket'$/)
     end
   end
 
@@ -67,7 +67,7 @@ describe 'duplicity::job' do
       should contain_file(spoolfile) \
         .with_content(/^AWS_ACCESS_KEY_ID='some_id'$/)\
         .with_content(/^AWS_SECRET_ACCESS_KEY='some_key'$/)\
-        .with_content(/^duplicity --full-if-older-than 30D --s3-use-new-style --no-encryption --include '\/etc\/' --exclude '\*\*' \/ 's3\+http:\/\/somebucket\/#{fqdn}\/some_backup_name\/'$/)
+        .with_content(/^duplicity --verbosity warning --no-print-statistics --full-if-older-than 30D --s3-use-new-style --no-encryption --include '\/etc\/' --exclude '\*\*' \/ 's3\+http:\/\/somebucket\/#{fqdn}\/some_backup_name\/'$/)
     end
 
 

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> --include '<%= @directory -%>' --exclude '**' / <%= @_target_url -%>
+duplicity --verbosity warning --no-print-statistics --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> --include '<%= @directory -%>' --exclude '**' / <%= @_target_url -%>
 <%= @_remove_older_than_command %>


### PR DESCRIPTION
The backup job scripts should not have any output under normal
conditions. Don't show statistics either. Only output errors and
warnings. This makes the mails from cron more usefull as they actually
contain something that needs attention.

If you want to merge all my pull request I also have them all merged into one branch on https://github.com/cirrax/puppet-duplicity/tree/cirrax