### PR TITLE
Allow multiple directories

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     "periodicnoise" : "https://github.com/Jimdo/puppet-periodicnoise.git"
+    "puppetlabs-stdlib" : "https://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     "duplicity": "#{source_dir}"

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -106,6 +106,12 @@ define duplicity::job(
     'file' => [],
   }
 
+  if is_array($directory) {
+    $_directories = $directory
+  } else {
+    $_directories = [$directory]
+  }
+
   $_target_url = $_cloud ? {
     'cf' => "'cf+http://$_bucket'",
     's3' => "'s3+http://$_bucket/$_folder/$name/'",

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -30,6 +30,24 @@ describe 'duplicity::job' do
       .with_mode('0700')
   end
 
+  context "multiple directories" do
+    let(:params) {
+      {
+        :bucket    => 'somebucket',
+        :directory => ['/etc/', '/var/'],
+        :dest_id   => 'some_id',
+        :dest_key  => 'some_key',
+        :cloud     => 'cf',
+        :spoolfile => spoolfile,
+      }
+    }
+
+    it "adds a spoolfile which contains the backup directories" do
+      should contain_file(spoolfile) \
+        .with_content(/duplicity .* --include '\/etc\/' --include '\/var\/' /)
+    end
+  end
+
   context "cloud files environment" do
 
     let(:params) {

--- a/templates/file-backup.sh.erb
+++ b/templates/file-backup.sh.erb
@@ -6,5 +6,5 @@ set -o pipefail
 <%= var %>
 <% end-%>
 <%= @_pre_command %>
-duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> --include '<%= @directory -%>' --exclude '**' / <%= @_target_url -%>
+duplicity --full-if-older-than <%= @_full_if_older_than -%> --s3-use-new-style <%= @_encryption -%> <% _directories.each do |dir| %>--include '<%= dir -%>' <% end %>--exclude '**' / <%= @_target_url -%>
 <%= @_remove_older_than_command %>


### PR DESCRIPTION
If the directory parameter is an array, backup all directories in the
array.

This adds a dependency on puppetlabs-stdlib.

If you want to merge all my pull request I also have them all merged into one branch on https://github.com/cirrax/puppet-duplicity/tree/cirrax